### PR TITLE
Add dhcp-ddns to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,6 @@ RUN make install
 # seem to need.
 RUN cd /usr/local/lib/ && \
     rm -v \
-        libkea-asiodns.* \
-        libkea-d2srv.so* \
-    && rm -v \
         *.la \
         kea/hooks/*.la
 
@@ -163,6 +160,13 @@ COPY --from=builder /hooks/libdhcp_ha.so /hooks/libdhcp_lease_cmds.so /usr/local
 FROM common AS ctrl-agent-target
 ENV KEA_EXECUTABLE=ctrl-agent
 COPY --from=builder /usr/local/sbin/kea-ctrl-agent /usr/local/sbin/
+
+#
+# The Kea DHCP DDNS service image.
+#
+FROM common AS dhcp-ddns-target
+ENV KEA_EXECUTABLE=dhcp-ddns
+COPY --from=builder /usr/local/sbin/kea-dhcp-ddns /usr/local/sbin/
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,14 @@ ctrl-agent:
 ctrl-agent-alpine:
 	./build.sh "ctrl-agent" $(KEA_VERSION) "alpine"
 
+.PHONY: dhcp-ddns
+dhcp-ddns:
+	./build.sh "dhcp-ddns" $(KEA_VERSION)
+
+.PHONY: dhcp-ddns-alpine
+dhcp-ddns-alpine:
+	./build.sh "dhcp-ddns" $(KEA_VERSION) "alpine"
+
 .PHONY: release
 release:
 	./build_release.sh $(KEA_VERSION)


### PR DESCRIPTION
Adds additional build target for kea-dhcp-ddns (and alpine flavor.)  libkea-asiodns and libkea-d2srv are required libraries in order to run the service.