### PR TITLE
Upgrade Kea to version 2.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,11 @@ RUN apt-get update && apt-get install -y \
 
 ARG KEA_VERSION
 # Download and unpack the correct tarball (also verify the signature).
-RUN curl -LOR "https://ftp.isc.org/isc/kea/${KEA_VERSION}/kea-${KEA_VERSION}.tar.gz{,.sha512.asc}" && \
+RUN curl -LOR "https://ftp.isc.org/isc/kea/${KEA_VERSION}/kea-${KEA_VERSION}.tar.gz{,.asc}" && \
     install -m 0700 -o root -g root -d /root/.gnupg && \
+    curl -L "https://www.isc.org/docs/isc-keyblock.asc" | gpg2 --import && \
     gpg2 --no-options --verbose --keyid-format 0xlong --keyserver-options auto-key-retrieve=true \
-        --verify kea-${KEA_VERSION}.tar.gz.sha512.asc kea-${KEA_VERSION}.tar.gz && \
+        --verify kea-${KEA_VERSION}.tar.gz.asc kea-${KEA_VERSION}.tar.gz && \
     tar xzpf kea-${KEA_VERSION}.tar.gz
 
 # Set the extracted location as our new workdir.

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -27,10 +27,11 @@ RUN set -e && apk add --no-cache \
 
 ARG KEA_VERSION
 # Download and unpack the correct tarball (also verify the signature).
-RUN curl -LOR "https://ftp.isc.org/isc/kea/${KEA_VERSION}/kea-${KEA_VERSION}.tar.gz{,.sha512.asc}" && \
+RUN curl -LOR "https://ftp.isc.org/isc/kea/${KEA_VERSION}/kea-${KEA_VERSION}.tar.gz{,.asc}" && \
     install -m 0700 -o root -g root -d /root/.gnupg && \
+    curl -L "https://www.isc.org/docs/isc-keyblock.asc" | gpg2 --import && \
     gpg2 --no-options --verbose --keyid-format 0xlong --keyserver-options auto-key-retrieve=true \
-        --verify kea-${KEA_VERSION}.tar.gz.sha512.asc kea-${KEA_VERSION}.tar.gz
+        --verify kea-${KEA_VERSION}.tar.gz.asc kea-${KEA_VERSION}.tar.gz
 # For some reason tar hangs if we do not do it in its own RUN...
 # Investigate this later.
 RUN tar xzpf kea-${KEA_VERSION}.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # The Makefile will be the "source of truth" when it comes to which version of
 # Kea we are to build. Having it in a single place will make life easier for us
 # in the future.
-KEA_VERSION="2.3.2"
+KEA_VERSION="2.3.6"
 
 # These are the build functions, they will in turn call upon the Bash script
 # with the correct arguments.


### PR DESCRIPTION
The only change besides the version upgrade is how the signature is verified. ISC has changed how releases are signed [1], specifically:

> February 2023 onward: with the 2021-2022 code-signing key expiring on February 1st, 2023, each source code release of ISC software made after that date will only be accompanied by a single SHA-512 signature file, `*.asc`, which will be prepared using one of the new signing keys.

[1] https://www.isc.org/blogs/2023-changes-to-isc-software-signing/