### PR TITLE
Strip debug symbols from binaries to reduce image size.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ RUN cd /usr/local/lib/ && \
     rm -v *.la && \
     rm -v kea/hooks/*.la
 
+# Strip debug symbols to reduce file size of binaries
+RUN find /usr/local/sbin/ /usr/local/lib/ -type f -exec strip --strip-unneeded {} \;
+
 # There are a couple additional "hook" features located in this folder which
 # will most likely not be needed by the average user, so let's exclude them
 # from the COPY step later.

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -53,6 +53,9 @@ RUN ls -ahl /usr/local/ && cd /usr/local/lib/ && \
     rm -v *.la && \
     rm -v kea/hooks/*.la
 
+# Strip debug symbols to reduce file size of binaries
+RUN find /usr/local/sbin/ /usr/local/lib/ -type f -exec strip --strip-unneeded {} \;
+
 # There are a couple additional "hook" features located in this folder which
 # will most likely not be needed by the average user, so let's exclude them
 # from the COPY step later.


### PR DESCRIPTION
Docker image size before stripping debug symbols:

```
jonasal/kea-dhcp4                  2.3.8-alpine   421d40ff9b08   3 days ago       348MB
jonasal/kea-dhcp4                  2.3.8          95bf362e5424   3 days ago       426MB
```

Docker image size after  stripping debug symbols:

```
kea-dhcp4                          local-alpine   711db7d44f17   17 minutes ago   98.3MB
kea-dhcp4                          local          1ef3046a3bee   48 seconds ago   114MB
```