### PR TITLE
ensure there is no pid file when kea starts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,11 @@ log() {
 }
 log "Starting Kea ${KEA_EXECUTABLE} container"
 
+# Make sure there is no leftover from previous process if it was abruptly aborted (power shutdown for instance).
+# Kea does not restart if the pid file from the previous process still exists. This ensures that it can restart
+# without any issue.
+rm -f /usr/local/var/run/kea/dhcp4.kea-dhcp4.pid
+
 # Execute any potential shell scripts in the entrypoint.d/ folder.
 find "/entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
     case "${f}" in

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ log "Starting Kea ${KEA_EXECUTABLE} container"
 # Make sure there is no leftover from previous process if it was abruptly aborted (power shutdown for instance).
 # Kea does not restart if the pid file from the previous process still exists. This ensures that it can restart
 # without any issue.
-rm -f /usr/local/var/run/kea/dhcp4.kea-dhcp4.pid
+rm -f /usr/local/var/run/kea/*.kea-"${KEA_EXECUTABLE}".pid
 
 # Execute any potential shell scripts in the entrypoint.d/ folder.
 find "/entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do


### PR DESCRIPTION
if a pid file from a previous process still exists, kea does not even start and display the following error message:

```bash
kea-dhcp4 already running? Daemon::createPIDFile: PID: 1 exists, PID file: /usr/local/var/run/kea/dhcp4.kea-dhcp4.pid
2023-08-29 19:13:55.558 FATAL [kea-dhcp4.dhcp4/1.139874453057408] DHCP4_ALREADY_RUNNING kea-dhcp4 already running? Daemon::createPIDFile: PID: 1 exists, PID file: /usr/local/var/run/kea/dhcp4.kea-dhcp4.pid
```

This can happen in case of abrupt shutdown of the container or process, like with a power shutdown or sigkill of the process for instance.