### PR TITLE
Update build system for 2.7.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN curl -LORf "https://ftp.isc.org/isc/kea/${KEA_VERSION}/kea-${KEA_VERSION}.ta
 # Set the extracted location as our new workdir.
 WORKDIR /kea-${KEA_VERSION}
 
+# PG libs are at /usr/lib/postgresql/{version}/lib
+RUN ln -snf /usr/lib/postgresql/15/lib/*.a /usr/lib/x86_64-linux-gnu/
+
 # Configure with all the settings we want, and then build it.
 # This will take ~5 hours for arm/v7 on an average 4 core desktop.
 RUN meson setup build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Define the base OS image in a single place.
 #
-FROM debian:bullseye-slim AS base
+FROM debian:bookworm-slim AS base
 
 #
 # The builder step is where Kea is compiled.
@@ -96,12 +96,12 @@ RUN addgroup --system --gid 101 ${KEA_USER} && \
 # This is not identical to what is pulled in when doing an apt-get install of
 # the official package, but it appears to work fine.
     apt-get update && apt-get install -y \
-        libboost-system1.74.0 \
+        libboost-system1.81.0 \
         libkrb5-3 \
         liblog4cplus-2.0.5 \
         libmariadb3 \
         libpq5 \
-        libssl1.1 \
+        libssl3 \
     && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,11 @@ FROM base AS builder
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install all packages needed to build Kea.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update
+RUN apt-get install -qq -y \
         apt-transport-https \
         gnupg2 \
-    && apt-get install -y \
+    && apt-get install -qq -y \
         build-essential \
         curl \
         libboost-system-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,31 +158,9 @@ COPY --from=builder /usr/local/sbin/kea-dhcp4 /usr/local/sbin/kea-lfc /usr/local
 #
 # The DHCP4 service image with all relevant hooks included.
 #
-# The libdhcp_mysql_cb.so and libdhcp_pgsql_cb.so libraries depend on the paid
-# libdhcp_cb_cmds.so library, so they are excluded.
 FROM dhcp4-slim AS dhcp4
 COPY --from=builder \
-    /hooks/libddns_gss_tsig.so \
-    /hooks/libdhcp_bootp.so \
-    /hooks/libdhcp_class_cmds.so \
-    /hooks/libdhcp_ddns_tuning.so \
-    /hooks/libdhcp_flex_id.so \
-    /hooks/libdhcp_flex_option.so \
-    /hooks/libdhcp_ha.so \
-    /hooks/libdhcp_host_cache.so \
-    /hooks/libdhcp_host_cmds.so \
-    /hooks/libdhcp_lease_cmds.so \
-    /hooks/libdhcp_lease_query.so \
-    /hooks/libdhcp_legal_log.so \
-    /hooks/libdhcp_limits.so \
-    /hooks/libdhcp_mysql.so \
-    /hooks/libdhcp_perfmon.so \
-    /hooks/libdhcp_pgsql.so \
-    /hooks/libdhcp_ping_check.so \
-    /hooks/libdhcp_radius.so \
-    /hooks/libdhcp_run_script.so \
-    /hooks/libdhcp_stat_cmds.so \
-    /hooks/libdhcp_subnet_cmds.so \
+    /hooks/* \
     /usr/local/lib/kea/hooks/
 
 
@@ -196,30 +174,9 @@ COPY --from=builder /usr/local/sbin/kea-dhcp6 /usr/local/sbin/kea-lfc /usr/local
 #
 # The DHCP6 service image with all relevant hooks included.
 #
-# The libdhcp_mysql_cb.so and libdhcp_pgsql_cb.so libraries depend on the paid
-# libdhcp_cb_cmds.so library, so they are excluded.
 FROM dhcp6-slim AS dhcp6
 COPY --from=builder \
-    /hooks/libddns_gss_tsig.so \
-    /hooks/libdhcp_class_cmds.so \
-    /hooks/libdhcp_ddns_tuning.so \
-    /hooks/libdhcp_flex_id.so \
-    /hooks/libdhcp_flex_option.so \
-    /hooks/libdhcp_ha.so \
-    /hooks/libdhcp_host_cache.so \
-    /hooks/libdhcp_host_cmds.so \
-    /hooks/libdhcp_lease_cmds.so \
-    /hooks/libdhcp_lease_query.so \
-    /hooks/libdhcp_legal_log.so \
-    /hooks/libdhcp_limits.so \
-    /hooks/libdhcp_mysql.so \
-    /hooks/libdhcp_perfmon.so \
-    /hooks/libdhcp_pgsql.so \
-    /hooks/libdhcp_ping_check.so \
-    /hooks/libdhcp_radius.so \
-    /hooks/libdhcp_run_script.so \
-    /hooks/libdhcp_stat_cmds.so \
-    /hooks/libdhcp_subnet_cmds.so \
+    /hooks/* \
     /usr/local/lib/kea/hooks/
 
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -14,17 +14,18 @@ RUN set -e && apk add --no-cache \
         curl \
         gnupg \
     && apk add --no-cache \
-        procps \
-        file \
+        meson \
         g++ \
-        make \
+        bison \
+        flex \
+        libcap \
+        python3-dev \
         boost-dev \
         openssl-dev \
         krb5-dev \
         log4cplus-dev \
         mariadb-dev \
-        postgresql-dev \
-        xz
+        postgresql-dev
 
 ARG KEA_VERSION
 # Download and unpack the correct tarball (also verify the signature).
@@ -42,20 +43,20 @@ WORKDIR /kea-${KEA_VERSION}
 
 # Configure with all the settings we want, and then build it.
 # This will take >7 hours for arm/v7 on an average 4 core desktop.
-RUN ./configure --with-openssl --with-mysql --with-pgsql --with-gssapi --enable-static=no && \
-    make -j$(nproc)
+RUN meson setup build \
+    --buildtype release \
+    --install-umask 0022 \
+    --libexecdir /usr/local/lib \
+    --prefix /usr/local \
+    -D mysql=enabled \
+    -D postgresql=enabled \
+    -D krb5=enabled \
+    -D crypto=openssl \
+    -D netconf=disabled
 
 # Having this in its own step makes it easier to experiment.
-RUN make install
-
-# Let's reduce the files needed to be copied later by removing stuff we don't
-# seem to need.
-RUN ls -ahl /usr/local/ && cd /usr/local/lib/ && \
-    rm -v *.la && \
-    rm -v kea/hooks/*.la
-
-# Strip debug symbols to reduce file size of binaries
-RUN find /usr/local/sbin/ /usr/local/lib/ -type f -exec strip --strip-unneeded {} \;
+RUN meson compile -C build
+RUN meson install -C build
 
 # There are a couple additional "hook" features located in this folder which
 # will most likely not be needed by the average user, so let's exclude them


### PR DESCRIPTION
Update to use the meson build system.
Also updated Debian to bookworm and relevant libraries.

Ref https://kea.readthedocs.io/en/kea-2.7.8/arm/install.html#set-up-the-build